### PR TITLE
feat: add support for key-value columns

### DIFF
--- a/src/Resource.spec.ts
+++ b/src/Resource.spec.ts
@@ -133,21 +133,18 @@ describe("Resource", () => {
       expect(recordInDb?.get("title")).toEqual(title);
     });
 
-    it.skipIf(dbConfig.config.dialect === "mariadb")(
-      "updates key-value column",
-      async () => {
-        await database.resource("post").update(post.id, {
-          some_json: { foo: "bar" },
-        });
+    it("updates key-value column", async () => {
+      await database.resource("post").update(post.id, {
+        some_json: { foo: "bar" },
+      });
 
-        const recordInDb = await fixtures.findOne(database.resource("post"), {
-          id: post.id,
-        });
-        expect(recordInDb?.get("some_json")).toMatchObject({
-          foo: "bar",
-        });
-      },
-    );
+      const recordInDb = await fixtures.findOne(database.resource("post"), {
+        id: post.id,
+      });
+      expect(recordInDb?.get("some_json")).toMatchObject({
+        foo: "bar",
+      });
+    });
   });
 
   describe("#findOne", () => {

--- a/src/Resource.spec.ts
+++ b/src/Resource.spec.ts
@@ -94,7 +94,7 @@ describe("Resource", () => {
       const user = await fixtures.createUser();
       const post = await database
         .resource("post")
-        .create(buildPost({ id: user.id! }));
+        .create(buildPost({ id: user.id }));
 
       const filter = new Filter(
         { author_id: post.author_id },
@@ -121,7 +121,7 @@ describe("Resource", () => {
       const user = await fixtures.createUser();
       post = await database
         .resource("post")
-        .create(buildPost({ id: user.id! }));
+        .create(buildPost({ id: user.id }));
     });
 
     it("updates string column", async () => {
@@ -150,7 +150,7 @@ describe("Resource", () => {
   describe("#findOne", () => {
     it("finds record by id", async () => {
       const user = await fixtures.createUser();
-      const record = await database.resource("user").findOne(user.id!);
+      const record = await database.resource("user").findOne(user.id);
       expect(record?.params).toMatchObject(user);
     });
   });
@@ -173,13 +173,13 @@ describe("Resource", () => {
   });
 
   describe("#find", () => {
-    let users: User[];
+    let users: Required<User>[];
 
     beforeAll(async () => {
-      users = [
-        await fixtures.createUser(),
-        await fixtures.createUser(),
-      ] as User[];
+      users = await Promise.all([
+        fixtures.createUser(),
+        fixtures.createUser(),
+      ])
     });
 
     it("finds by record name", async () => {
@@ -235,7 +235,7 @@ describe("Resource", () => {
   //   let profileResource: Resource;
   //
   //   beforeEach(async () => {
-  //     user = await fixtures.createUser() as User;
+  //     user = await fixtures.createUser()
   //     profileResource = await getResource("profile");
   //   });
   //
@@ -250,15 +250,15 @@ describe("Resource", () => {
   // });
 
   describe("#delete", () => {
-    let user: User;
+    let user: Required<User>;
 
     beforeEach(async () => {
-      user = (await fixtures.createUser()) as User;
+      user = await fixtures.createUser()
     });
 
     it("deletes the resource", async () => {
-      await database.resource("user").delete(user.id!);
-      expect(await database.resource("user").findOne(user.id!)).toBe(null);
+      await database.resource("user").delete(user.id);
+      expect(await database.resource("user").findOne(user.id)).toBe(null);
     });
   });
 });

--- a/src/Resource.spec.ts
+++ b/src/Resource.spec.ts
@@ -1,4 +1,4 @@
-import { BaseProperty, Filter } from "adminjs";
+import { BaseProperty, Filter, type ParamsType } from "adminjs";
 import { beforeAll, beforeEach, describe, expect, it } from "vitest";
 
 import { Database } from "./Database.js";
@@ -6,13 +6,9 @@ import { Property } from "./Property.js";
 import { Resource } from "./Resource.js";
 import { ResourceMetadata } from "./metadata/index.js";
 import { getDatabase } from "./test/db.js";
-import {
-  buildPost,
-  buildProfile,
-  buildUser,
-  getAdapter,
-} from "./test/fixtures.js";
+import { buildPost, buildProfile, getAdapter } from "./test/fixtures.js";
 import type { User } from "./test/types.js";
+import { useFixtures } from "./test/useFixtures.js";
 
 const dbConfig = getDatabase();
 
@@ -21,6 +17,8 @@ async function getResource(table: string) {
   const databaseMetadata = await adapter.init();
   return new Database(databaseMetadata).resource(table);
 }
+
+const fixtures = useFixtures();
 
 describe("Resource", () => {
   let database: Database;
@@ -90,52 +88,81 @@ describe("Resource", () => {
 
   describe("#count", () => {
     it("returns number of records", async () => {
-      const count = await database.resource("post").count({} as Filter);
+      let count = await database.resource("post").count({} as Filter);
       expect(count).toBeGreaterThanOrEqual(0);
+
+      const user = await fixtures.createUser();
+      const post = await database
+        .resource("post")
+        .create(buildPost({ id: user.id! }));
+
+      const filter = new Filter(
+        { author_id: post.author_id },
+        database.resource("post"),
+      );
+
+      count = await database.resource("post").count(filter);
+      expect(count).toEqual(1);
     });
   });
 
   describe("#create", () => {
     it("returns params", async () => {
-      const user = await database.resource("user").create(buildUser());
+      const user = await fixtures.createUser();
 
       expect(user.id).toBeDefined();
     });
   });
 
   describe("#update", () => {
-    it("updates record name", async () => {
-      const user = await database.resource("user").create(buildUser());
-      const post = await database
+    let post: ParamsType;
+
+    beforeEach(async () => {
+      const user = await fixtures.createUser();
+      post = await database
         .resource("post")
         .create(buildPost({ id: user.id! }));
-      const record = await database.resource("post").findOne(post.id);
-      const title = "Michael";
+    });
 
-      await database.resource("post").update(record?.id() as string, {
+    it("updates string column", async () => {
+      const title = "Michael";
+      await database.resource("post").update(post.id, {
         title,
       });
-      const recordInDb = await database
-        .resource("post")
-        .findOne(record?.id() as string);
+      const recordInDb = await database.resource("post").findOne(post.id);
       expect(recordInDb?.get("title")).toEqual(title);
     });
+
+    it.skipIf(dbConfig.config.dialect === "mariadb")(
+      "updates key-value column",
+      async () => {
+        await database.resource("post").update(post.id, {
+          some_json: { foo: "bar" },
+        });
+
+        const recordInDb = await fixtures.findOne(database.resource("post"), {
+          id: post.id,
+        });
+        expect(recordInDb?.get("some_json")).toMatchObject({
+          foo: "bar",
+        });
+      },
+    );
   });
 
   describe("#findOne", () => {
     it("finds record by id", async () => {
-      const userObject = buildUser();
-      await database.resource("user").create(userObject);
-      const record = await database.resource("user").findOne(userObject.id!);
-      expect(record?.params).toMatchObject(userObject);
+      const user = await fixtures.createUser();
+      const record = await database.resource("user").findOne(user.id!);
+      expect(record?.params).toMatchObject(user);
     });
   });
 
   describe("#findMany", () => {
     it("finds records by ids", async () => {
       const users = await Promise.all([
-        database.resource("user").create(buildUser()),
-        database.resource("user").create(buildUser()),
+        fixtures.createUser(),
+        fixtures.createUser(),
       ]);
 
       const records = await database
@@ -153,8 +180,8 @@ describe("Resource", () => {
 
     beforeAll(async () => {
       users = [
-        await database.resource("user").create(buildUser()),
-        await database.resource("user").create(buildUser()),
+        await fixtures.createUser(),
+        await fixtures.createUser(),
       ] as User[];
     });
 
@@ -211,7 +238,7 @@ describe("Resource", () => {
   //   let profileResource: Resource;
   //
   //   beforeEach(async () => {
-  //     user = await database.resource("user").create(buildUser()) as User;
+  //     user = await fixtures.createUser() as User;
   //     profileResource = await getResource("profile");
   //   });
   //
@@ -229,7 +256,7 @@ describe("Resource", () => {
     let user: User;
 
     beforeEach(async () => {
-      user = (await database.resource("user").create(buildUser())) as User;
+      user = (await fixtures.createUser()) as User;
     });
 
     it("deletes the resource", async () => {

--- a/src/Resource.spec.ts
+++ b/src/Resource.spec.ts
@@ -119,9 +119,7 @@ describe("Resource", () => {
 
     beforeEach(async () => {
       const user = await fixtures.createUser();
-      post = await database
-        .resource("post")
-        .create(buildPost({ id: user.id }));
+      post = await database.resource("post").create(buildPost({ id: user.id }));
     });
 
     it("updates string column", async () => {
@@ -176,10 +174,7 @@ describe("Resource", () => {
     let users: Required<User>[];
 
     beforeAll(async () => {
-      users = await Promise.all([
-        fixtures.createUser(),
-        fixtures.createUser(),
-      ])
+      users = await Promise.all([fixtures.createUser(), fixtures.createUser()]);
     });
 
     it("finds by record name", async () => {
@@ -253,7 +248,7 @@ describe("Resource", () => {
     let user: Required<User>;
 
     beforeEach(async () => {
-      user = await fixtures.createUser()
+      user = await fixtures.createUser();
     });
 
     it("deletes the resource", async () => {

--- a/src/test/env.ts
+++ b/src/test/env.ts
@@ -30,12 +30,13 @@ export const getEnv = (): Env => {
 };
 
 export const logEnv = (env: Env) => {
-  // biome-ignore lint/suspicious/noConsoleLog: <explanation>
-  console.log(
-    "Test environment:",
-    Object.entries(env).filter(
+  const envString = Object.entries(env)
+    .filter(
       ([key]) =>
         key.startsWith("DB_") || key === "DIALECT" || key === "SERVICE",
-    ),
-  );
+    )
+    .map(([key, value]) => `${key}=${value}`)
+    .join("\n");
+  // biome-ignore lint/suspicious/noConsoleLog: <explanation>
+  console.log("Test environment:\n", envString.trim());
 };

--- a/src/test/fixtures.ts
+++ b/src/test/fixtures.ts
@@ -2,7 +2,6 @@ import crypto from "node:crypto";
 
 import { Adapter } from "../Adapter.js";
 import type { ConnectionOptions } from "../dialects/index.js";
-
 import type { DatabaseConfig, Post, Profile, User } from "./types.js";
 
 export const buildUser = (): User => ({

--- a/src/test/migration.ts
+++ b/src/test/migration.ts
@@ -50,6 +50,11 @@ const getMigration = (
         table.dateTime("created_at").notNullable().defaultTo(knex.fn.now());
         table.dateTime("updated_at").notNullable().defaultTo(knex.fn.now());
         table.json("some_json");
+
+        if (isMySqlDialect(dialect)) {
+          table.check("JSON_VALID(some_json)");
+        }
+
         table
           .enum("status", ["ACTIVE", "INACTIVE"], {
             useNative: true,

--- a/src/test/useFixtures.ts
+++ b/src/test/useFixtures.ts
@@ -18,7 +18,7 @@ export function useFixtures() {
   const fixtures = {
     async createUser() {
       const user = await database.resource("user").create(buildUser());
-      return user;
+      return user as Required<User>;
     },
     async findMany<T = User | Profile | Post>(
       resource: Resource,

--- a/src/test/useFixtures.ts
+++ b/src/test/useFixtures.ts
@@ -1,0 +1,32 @@
+import { type BaseRecord, Filter } from "adminjs";
+import type { Database } from "../Database.js";
+import type { Resource } from "../Resource.js";
+import { buildUser } from "./fixtures.js";
+import type { Post, Profile, User } from "./types.js";
+
+export function useFixtures() {
+  let database: Database;
+
+  const fixtures = {
+    async createUser() {
+      const user = await database.resource("user").create(buildUser());
+      return user;
+    },
+    async findMany<T = User | Profile | Post>(
+      resource: Resource,
+      filterParams: Partial<T>,
+    ): Promise<BaseRecord[]> {
+      const filter = new Filter({ ...filterParams }, resource);
+      return await resource.find(filter);
+    },
+    async findOne<T = User | Profile | Post>(
+      resource: Resource,
+      filter: Partial<T>,
+    ): Promise<BaseRecord> {
+      const records = await fixtures.findMany(resource, filter);
+      return records[0];
+    },
+  };
+
+  return fixtures;
+}

--- a/src/test/useFixtures.ts
+++ b/src/test/useFixtures.ts
@@ -1,11 +1,19 @@
 import { type BaseRecord, Filter } from "adminjs";
-import type { Database } from "../Database.js";
+import { beforeAll } from "vitest";
+import { Database } from "../Database.js";
 import type { Resource } from "../Resource.js";
-import { buildUser } from "./fixtures.js";
+import { getDatabaseConfig } from "./db.js";
+import { buildUser, getAdapter } from "./fixtures.js";
 import type { Post, Profile, User } from "./types.js";
 
 export function useFixtures() {
   let database: Database;
+
+  beforeAll(async () => {
+    const adapter = getAdapter(getDatabaseConfig());
+    const databaseMetadata = await adapter.init();
+    database = new Database(databaseMetadata);
+  });
 
   const fixtures = {
     async createUser() {

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,0 +1,7 @@
+export const safeParseJSON = (json: string): Record<string, any> | null => {
+  try {
+    return JSON.parse(json);
+  } catch (_error) {
+    return null;
+  }
+};


### PR DESCRIPTION
Adds support for `key-value` properties aka `json` columns for `postgres | mysql | mariadb`.

 `mariadb` uses `longtext` for `json` columns so `json` columns are inferred from `json_valid` constraints. 